### PR TITLE
If the user does not have a stormpath principal, we attempt to use th…

### DIFF
--- a/core/src/main/java/com/stormpath/shiro/realm/ApplicationRealm.java
+++ b/core/src/main/java/com/stormpath/shiro/realm/ApplicationRealm.java
@@ -426,6 +426,10 @@ public class ApplicationRealm extends AuthorizingRealm {
     protected String getAccountHref(PrincipalCollection principals) {
         Collection c = principals.fromRealm(getName());
         //Based on the createPrincipals implementation above, the first one is the Account href:
+        if (c.isEmpty())
+        {
+            return principals.getPrimaryPrincipal().toString();
+        }
         return (String) c.iterator().next();
     }
 


### PR DESCRIPTION
If the user does not have a stormpath principal, we attempt to use the primary principal for authz so that we can leverage things like passthrough authenticators but still use stormpath permissions.
